### PR TITLE
Add _key to Navigator()

### DIFF
--- a/lib/src/go_router_impl.dart
+++ b/lib/src/go_router_impl.dart
@@ -553,6 +553,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
     return builderWithNav(
       context,
       Navigator(
+        key: _key,
         pages: pages,
         observers: observers,
         onPopPage: (route, dynamic result) {


### PR DESCRIPTION
The `final _key = GlobalKey<NavigatorState>();` was never used, so currentState was always null.

`PopNavigatorRouterDelegateMixin` documents:
```dart
///When using this mixin, be sure to use this key to create the navigator.
GlobalKey<NavigatorState>? get navigatorKey;
```
So by adding the `_key` to the `Navigator()`, this should fix #57 .
