### PR TITLE
ci: only check for changed `*.dart` files when validating

### DIFF
--- a/.github/workflows/scripts/validate-formatting.sh
+++ b/.github/workflows/scripts/validate-formatting.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-if [[ $(git ls-files --modified) ]]; then
+if [[ $(git ls-files '*.dart' --modified) ]]; then
   echo ""
   echo ""
   echo "These files are not formatted correctly:"
-  for f in $(git ls-files --modified); do
+  for f in $(git ls-files '*.dart' --modified); do
     echo ""
     echo ""
     echo "-----------------------------------------------------------------"


### PR DESCRIPTION
Fixes CI saying pubspec lock files have changed when validating formatting.