### PR TITLE
Add a locator function to GoRouterState

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,6 +749,28 @@ by setting the `redirectLimit` argument to the `GoRouter` constructor.
 
 The other trouble you need worry about is getting into a loop, e.g. `/ => /foo => /`. If that happens, you'll get an exception.
 
+## Retrieve a dependency in the redirect function
+
+It can be useful to be able to request a part of the app's state inside the `redirect` function.
+To be able to do it, you can pass a `locator` function to `GoRouter` which will serves as a service locator and available in all `GoRouterState` objects.
+
+For example, if you use [the provider package](https://pub.dev/packages/provider), you can create the `GoRouter` instance in the `State` of a `StatefulWidget` like this:
+
+```dart
+late final _router = GoRouter(
+  locator: context.read,
+  routes: ...,
+  errorPageBuilder: ...,
+  redirect: (state) {
+    final locator = state.locator;
+    if (locator != null) {
+      // To retrieve a dependency, we just have to call the locator.
+      final myDependency = locator<MyDependency>();
+    }
+  },
+);
+```
+
 # Query Parameters
 
 Sometimes you're doing [deep linking](#deep-linking) and you'd like a user to

--- a/example/lib/redirection_with_locator.dart
+++ b/example/lib/redirection_with_locator.dart
@@ -7,6 +7,26 @@ import 'shared/pages.dart';
 
 final loginInfo = LoginInfo();
 
+// The redirect function can be global or outside of a StatefulWidget and we
+// are able to get our dependency in the function.
+String? _redirect(GoRouterState state) {
+  final locator = state.locator;
+  if (locator != null) {
+    final loginInfo = locator<LoginInfo>();
+    final loggedIn = loginInfo.loggedIn;
+    final goingToLogin = state.location == '/login';
+
+    // the user is not logged in and not headed to /login, they need to login
+    if (!loggedIn && !goingToLogin) return '/login';
+
+    // the user is logged in and headed to /login, no need to login again
+    if (loggedIn && goingToLogin) return '/';
+
+    // no need to redirect at all
+    return null;
+  }
+}
+
 void main() => runApp(
       ChangeNotifierProvider.value(
         value: loginInfo,
@@ -74,31 +94,14 @@ class _AppState extends State<App> {
         ),
       ),
     ],
-
     errorPageBuilder: (context, state) => MaterialPage<void>(
       key: state.pageKey,
       child: ErrorPage(state.error),
     ),
-
-    // redirect to the login page if the user is not logged in
-    redirect: (state) {
-      final locator = state.locator;
-      if (locator != null) {
-        final loginInfo = locator<LoginInfo>();
-        final loggedIn = loginInfo.loggedIn;
-        final goingToLogin = state.location == '/login';
-
-        // the user is not logged in and not headed to /login, they need to login
-        if (!loggedIn && !goingToLogin) return '/login';
-
-        // the user is logged in and headed to /login, no need to login again
-        if (loggedIn && goingToLogin) return '/';
-
-        // no need to redirect at all
-        return null;
-      }
-    },
-
+    // redirect to the login page if the user is not logged in and using a
+    // top-level function to demonstrate how to get dependency through the
+    // locator without being able to get the context.
+    redirect: _redirect,
     // changes on the listenable will cause the router to refresh it's route
     refreshListenable: loginInfo,
   );

--- a/example/lib/redirection_with_locator.dart
+++ b/example/lib/redirection_with_locator.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+import 'shared/data.dart';
+import 'shared/pages.dart';
+
+final loginInfo = LoginInfo();
+
+void main() => runApp(
+      ChangeNotifierProvider.value(
+        value: loginInfo,
+        child: const App(),
+      ),
+    );
+
+/// sample app using a locator to redirect to another location
+class App extends StatefulWidget {
+  const App({Key? key}) : super(key: key);
+
+  @override
+  State<App> createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  @override
+  Widget build(BuildContext context) => MaterialApp.router(
+        routeInformationParser: _router.routeInformationParser,
+        routerDelegate: _router.routerDelegate,
+        title: 'GoRouter Example: Redirection with Locator',
+        debugShowCheckedModeBanner: false,
+      );
+
+  late final _router = GoRouter(
+    locator: context.read,
+    routes: [
+      GoRoute(
+        path: '/',
+        pageBuilder: (context, state) => MaterialPage<void>(
+          key: state.pageKey,
+          child: HomePage(families: Families.data),
+        ),
+        routes: [
+          GoRoute(
+            path: 'family/:fid',
+            pageBuilder: (context, state) {
+              final family = Families.family(state.params['fid']!);
+              return MaterialPage<void>(
+                key: state.pageKey,
+                child: FamilyPage(family: family),
+              );
+            },
+            routes: [
+              GoRoute(
+                path: 'person/:pid',
+                pageBuilder: (context, state) {
+                  final family = Families.family(state.params['fid']!);
+                  final person = family.person(state.params['pid']!);
+                  return MaterialPage<void>(
+                    key: state.pageKey,
+                    child: PersonPage(family: family, person: person),
+                  );
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/login',
+        pageBuilder: (context, state) => MaterialPage<void>(
+          key: state.pageKey,
+          child: const LoginPage(),
+        ),
+      ),
+    ],
+
+    errorPageBuilder: (context, state) => MaterialPage<void>(
+      key: state.pageKey,
+      child: ErrorPage(state.error),
+    ),
+
+    // redirect to the login page if the user is not logged in
+    redirect: (state) {
+      final locator = state.locator;
+      if (locator != null) {
+        final loginInfo = locator<LoginInfo>();
+        final loggedIn = loginInfo.loggedIn;
+        final goingToLogin = state.location == '/login';
+
+        // the user is not logged in and not headed to /login, they need to login
+        if (!loggedIn && !goingToLogin) return '/login';
+
+        // the user is logged in and headed to /login, no need to login again
+        if (loggedIn && goingToLogin) return '/';
+
+        // no need to redirect at all
+        return null;
+      }
+    },
+
+    // changes on the listenable will cause the router to refresh it's route
+    refreshListenable: loginInfo,
+  );
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -202,7 +202,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -258,7 +258,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/lib/src/go_router.dart
+++ b/lib/src/go_router.dart
@@ -28,6 +28,7 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
     bool debugLogDiagnostics = false,
     TransitionBuilder? navigatorBuilder,
     String? restorationScopeId,
+    GoRouterLocator? locator,
   }) {
     if (urlPathStrategy != null) setUrlPathStrategy(urlPathStrategy);
 
@@ -41,6 +42,7 @@ class GoRouter extends ChangeNotifier with NavigatorObserver {
       observers: [...observers ?? [], this],
       debugLogDiagnostics: debugLogDiagnostics,
       restorationScopeId: restorationScopeId,
+      locator: locator,
       // wrap the returned Navigator to enable GoRouter.of(context).go() et al,
       // allowing the caller to wrap the navigator themselves
       builderWithNav: (context, nav) => InheritedGoRouter(

--- a/lib/src/go_router_delegate.dart
+++ b/lib/src/go_router_delegate.dart
@@ -28,6 +28,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
     required this.observers,
     required this.debugLogDiagnostics,
     this.restorationScopeId,
+    this.locator,
   }) {
     // check top-level route paths are valid
     for (final route in routes) {
@@ -78,6 +79,10 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   /// Restoration ID to save and restore the state of the navigator, including
   /// its history.
   final String? restorationScopeId;
+
+  /// Function that can be used to get dependencies and which is passed to the
+  /// [GoRouterState] during redirection.
+  final GoRouterLocator? locator;
 
   final _key = GlobalKey<NavigatorState>();
   final List<GoRouteMatch> _matches = [];
@@ -329,6 +334,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
               subloc: uri.path,
               // pass along the query params 'cuz that's all we have right now
               queryParams: uri.queryParameters,
+              locator: locator,
             ),
           ),
         )) continue;
@@ -357,6 +363,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
               params: params,
               queryParams: top.queryParams,
               extra: extra,
+              locator: locator,
             ),
           ),
         )) continue;
@@ -400,6 +407,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
                 params: state.params,
                 queryParams: state.queryParams,
                 extra: state.extra,
+                locator: locator,
               ),
             ),
           ),
@@ -626,6 +634,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
             name: null,
             queryParams: uri.queryParameters,
             error: err is Exception ? err : Exception(err),
+            locator: locator,
           ),
         ),
       ];
@@ -708,6 +717,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
           queryParams: match.queryParams,
           extra: match.extra,
           pageKey: match.pageKey, // push() remaps the page key for uniqueness
+          locator: locator,
         ),
       );
     }

--- a/lib/src/go_router_state.dart
+++ b/lib/src/go_router_state.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 import 'go_router_delegate.dart';
+import 'typedefs.dart';
 
 /// The route state during routing.
 class GoRouterState {
@@ -17,6 +18,7 @@ class GoRouterState {
     this.extra,
     this.error,
     ValueKey<String>? pageKey,
+    this.locator,
   })  : pageKey = pageKey ??
             ValueKey(error != null
                 ? 'error'
@@ -56,6 +58,10 @@ class GoRouterState {
 
   /// A unique string key for this sub-route, e.g. ValueKey('/family/:fid')
   final ValueKey<String> pageKey;
+
+  /// A function used to get dependencies.
+  /// It can be used for example in the redirect function.
+  final GoRouterLocator? locator;
 
   /// Get a location from route name and parameters.
   /// This is useful for redirecting to a named location.

--- a/lib/src/typedefs.dart
+++ b/lib/src/typedefs.dart
@@ -23,3 +23,6 @@ typedef GoRouterPageBuilder = Page<dynamic> Function(
 
 /// The signature of the redirect callback.
 typedef GoRouterRedirect = String? Function(GoRouterState state);
+
+/// Signature of function that serves as a service locator.
+typedef GoRouterLocator = T Function<T>();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -85,7 +85,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -153,7 +153,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -167,7 +167,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/test/go_router_test.dart
+++ b/test/go_router_test.dart
@@ -1054,6 +1054,42 @@ void main() {
       expect((router.pageFor(matches[0]) as ErrorPage).ex, isNotNull);
       dump((router.pageFor(matches[0]) as ErrorPage).ex);
     });
+
+    test('use locator in redirect', () {
+      final routes = [
+        GoRoute(
+          path: '/',
+          pageBuilder: (builder, state) => HomePage(),
+        ),
+      ];
+
+      final dependencies = <Type, Object>{
+        int: 42,
+        String: 'Flutter Rocks',
+      };
+
+      T get<T>() {
+        return dependencies[T] as T;
+      }
+
+      final results = <Object>[];
+
+      final router = GoRouter(
+        routes: routes,
+        errorPageBuilder: _dummy,
+        locator: get,
+        redirect: (state) {
+          final locator = state.locator;
+          if (locator != null) {
+            results.add(locator<int>());
+            results.add(locator<String>());
+          }
+          return null;
+        },
+      );
+      expect(router.location, '/');
+      expect(results, [42, 'Flutter Rocks']);
+    });
   });
 
   group('initial location', () {


### PR DESCRIPTION
This is the complete implementation of the solution suggested in #184.
It would enable users to be able to get dependencies from any redirect callback through `state.locator`.