### PR TITLE
Remove scheduleMicrotask wrapping of notifyListeners

### DIFF
--- a/go_router/lib/src/go_router_delegate.dart
+++ b/go_router/lib/src/go_router_delegate.dart
@@ -155,21 +155,21 @@ class GoRouterDelegate extends RouterDelegate<Uri>
   void go(String location, {Object? extra}) {
     log.info('going to $location');
     _go(location, extra: extra);
-    _safeNotifyListeners();
+    _notifyListeners();
   }
 
   /// push the given location onto the page stack
   void push(String location, {Object? extra}) {
     log.info('pushing $location');
     _push(location, extra: extra);
-    _safeNotifyListeners();
+    _notifyListeners();
   }
 
   /// Refresh the current location, including re-evaluating redirections.
   void refresh() {
     log.info('refreshing $location');
     _go(location, extra: _matches.last.extra);
-    _safeNotifyListeners();
+    _notifyListeners();
   }
 
   /// Get the current location, e.g. /family/f2/person/p1
@@ -343,7 +343,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
 
         // let Router know to update the address bar
         // (the initial route is not a redirect)
-        if (redirects.length > 1) _safeNotifyListeners();
+        if (redirects.length > 1) _notifyListeners();
 
         // no more redirects!
         break;
@@ -632,7 +632,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
 
           // this hack allows the browser's address bar to be updated after a
           // push and pressing the Back button, but it shouldn't be necessary...
-          _safeNotifyListeners();
+          _notifyListeners();
 
           return true;
         },
@@ -837,12 +837,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
         Uri(path: uri.path, queryParameters: queryParams).toString());
   }
 
-  void _safeNotifyListeners() {
-    // this is a hack to fix the following error:
-    // The following assertion was thrown while dispatching notifications for
-    // GoRouterDelegate: setState() or markNeedsBuild() called during build.
-    WidgetsBinding.instance == null
-        ? notifyListeners()
-        : scheduleMicrotask(notifyListeners);
+  void _notifyListeners() {
+    notifyListeners();
   }
 }


### PR DESCRIPTION
- Removed scheduleMicrotask wrapping of notifyListeners since the hack seems to be unneeded now. 
- Renamed _safeNotifyListeners to _notifyListeners.
- Although _notifyListeners could be replaced with a direct call to notifyListeners, we should leave it wrapped since the follow on PR to enable Router.neglect will require it anyway.

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Removes unneeded wrapping of notifyListeners in scheduleMicrotask
### :arrow_heading_down: What is the current behavior?
Wrapping notifyListeners currently moves its execution out of scope and prevents wrapping with Router.neglect or Router.navigate.

### :new: What is the new behavior (if this is a feature change)?
Removing scheduleMicrotask keeps execution within the current task.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
All tests pass, and all examples run, there isn't any direct test of the original hack so observation is it.

### :memo: Links to relevant issues/docs
https://github.com/csells/go_router/issues/226

### :thinking: Checklist before submitting

- [x] I made sure all projects build.
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated the relevant documentation.
- [x] I updated the relevant code example.
- [x] I rebased onto current `master`.
