### PR TITLE
add onCreate / onDispose methods

### DIFF
--- a/go_router/lib/src/go_route.dart
+++ b/go_router/lib/src/go_route.dart
@@ -14,7 +14,9 @@ class GoRoute {
     required this.path,
     this.name,
     this.pageBuilder,
+    this.onCreate,
     this.builder = _builder,
+    this.onDispose,
     this.routes = const [],
     this.redirect = _redirect,
   }) {
@@ -57,6 +59,9 @@ class GoRoute {
         );
       }
     }
+
+    // perform custom logic on GoRoute create
+    onCreate?.call();
   }
 
   final _pathParams = <String>[];
@@ -113,6 +118,35 @@ class GoRoute {
   /// ```
   ///
   final GoRouterWidgetBuilder builder;
+
+  /// An optional callback to perform custom actions before the page is spawned,
+  /// e.g. register some dependencies
+  ///
+  /// For example
+  /// ```
+  /// GoRoute(
+  ///   path: '/',
+  ///   onCreate: () => GetIt.I.registerSingleton(() => MyController()),
+  ///   builder: (context, state) => const MyPage(),
+  ///   ),
+  /// ),
+  /// ```
+  final VoidCallback? onCreate;
+
+  /// A place to cleanup resources, e.g. remove dependencies
+  ///
+  /// For example
+  /// ```
+  /// GoRoute(
+  ///   path: '/',
+  ///   onCreate: () => GetIt.I.registerSingleton(() => MyController()),
+  ///   builder: (context, state) => const MyPage(),
+  ///   onDispose: () => GetIt.I.unregister<MyController>(
+  ///     disposingFunction: (controller) => controller.dispose(),
+  ///   ),
+  /// ),
+  /// ```
+  final VoidCallback? onDispose;
 
   /// A list of sub go routes for this route.
   ///

--- a/go_router/lib/src/go_router_delegate.dart
+++ b/go_router/lib/src/go_router_delegate.dart
@@ -172,6 +172,8 @@ class GoRouterDelegate extends RouterDelegate<Uri>
 
   /// Pop the top page off the GoRouter's page stack.
   void pop() {
+    // perform custom logic on GoRoute destroy
+    _matches.last.route.onDispose?.call();
     _matches.remove(_matches.last);
     if (_matches.isEmpty) {
       throw Exception(


### PR DESCRIPTION
Continuing this topic https://github.com/csells/go_router/issues/297

i have added experimental onCreate / onDispose callbacks to GoRoute
my idea is that I can register / unregister dependencies in these callbacks with custom IoC (GetIt / Kiwi or other)

**haven't tested it yet**