### PR TITLE
adds extra to the GoRouterState avaliable to navigatorBuilder

### DIFF
--- a/go_router/lib/src/go_router_delegate.dart
+++ b/go_router/lib/src/go_router_delegate.dart
@@ -656,6 +656,7 @@ class GoRouterDelegate extends RouterDelegate<Uri>
       GoRouterState(
         this,
         location: location,
+        extra: matches.last.extra,
         name: null, // no name available at the top level
         // trim the query params off the subloc to match route.redirect
         subloc: uri.path,


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
the GoRouterState from navigatorBuilder does not have `extra`.

### :new: What is the new behavior (if this is a feature change)?
`extra` is no longer null in the GoRouterState in navigatorBuilder.

### :boom: Does this PR introduce a breaking change?
Don't think so.

### :bug: Recommendations for testing
Not sure.

### :memo: Links to relevant issues/docs
#318 

### :thinking: Checklist before submitting
Tested nav_builder.dart, extra_param.dart, and the default project.
- [ ] I made sure all projects build. 
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated the relevant documentation.
- [ ] I updated the relevant code example.
- [✅ ] I rebased onto current `master`.
