### PR TITLE
added_barrier_dissmissable_pagebuilder_to_customtransitionpage

### DIFF
--- a/go_router/example/lib/books/main.dart
+++ b/go_router/example/lib/books/main.dart
@@ -152,7 +152,7 @@ class FadeTransitionPage extends CustomTransitionPage<void> {
                   opacity: animation.drive(_curveTween),
                   child: child,
                 ),
-            child: child);
+            pageBuilder: (context, anim1, anim2) => child);
 
   static final _curveTween = CurveTween(curve: Curves.easeIn);
 }

--- a/go_router/example/lib/transitions.dart
+++ b/go_router/example/lib/transitions.dart
@@ -25,7 +25,8 @@ class App extends StatelessWidget {
         path: '/fade',
         pageBuilder: (context, state) => CustomTransitionPage<void>(
           key: state.pageKey,
-          child: const ExampleTransitionsScreen(
+          pageBuilder: (context, anim1, anim2) =>
+              const ExampleTransitionsScreen(
             kind: 'fade',
             color: Colors.red,
           ),
@@ -37,7 +38,8 @@ class App extends StatelessWidget {
         path: '/scale',
         pageBuilder: (context, state) => CustomTransitionPage<void>(
           key: state.pageKey,
-          child: const ExampleTransitionsScreen(
+          pageBuilder: (context, anim1, anim2) =>
+              const ExampleTransitionsScreen(
             kind: 'scale',
             color: Colors.green,
           ),
@@ -49,7 +51,8 @@ class App extends StatelessWidget {
         path: '/slide',
         pageBuilder: (context, state) => CustomTransitionPage<void>(
           key: state.pageKey,
-          child: const ExampleTransitionsScreen(
+          pageBuilder: (context, anim1, anim2) =>
+              const ExampleTransitionsScreen(
             kind: 'slide',
             color: Colors.yellow,
           ),
@@ -68,7 +71,8 @@ class App extends StatelessWidget {
         path: '/rotation',
         pageBuilder: (context, state) => CustomTransitionPage<void>(
           key: state.pageKey,
-          child: const ExampleTransitionsScreen(
+          pageBuilder: (context, anim1, anim2) =>
+              const ExampleTransitionsScreen(
             kind: 'rotation',
             color: Colors.purple,
           ),

--- a/go_router/lib/src/custom_transition_page.dart
+++ b/go_router/lib/src/custom_transition_page.dart
@@ -10,7 +10,7 @@ class CustomTransitionPage<T> extends Page<T> {
   /// To be used instead of MaterialPage or CupertinoPage, which provide
   /// their own transitions.
   const CustomTransitionPage({
-    required this.child,
+    required this.pageBuilder,
     required this.transitionsBuilder,
     this.transitionDuration = const Duration(milliseconds: 300),
     this.maintainState = true,
@@ -31,7 +31,7 @@ class CustomTransitionPage<T> extends Page<T> {
         );
 
   /// The content to be shown in the Route created by this page.
-  final Widget child;
+  final RoutePageBuilder pageBuilder;
 
   /// A duration argument to customize the duration of the custom page
   /// transition.
@@ -134,7 +134,7 @@ class _CustomTransitionPageRoute<T> extends PageRoute<T> {
       Semantics(
         scopesRoute: true,
         explicitChildNodes: true,
-        child: _page.child,
+        child: _page.pageBuilder(context, animation, secondaryAnimation),
       );
 
   @override
@@ -155,26 +155,21 @@ class _CustomTransitionPageRoute<T> extends PageRoute<T> {
 /// Custom transition page with no transition.
 class NoTransitionPage<T> extends CustomTransitionPage<T> {
   /// Constructor for a page with no transition functionality.
-  const NoTransitionPage({
-    required Widget child,
+  NoTransitionPage({
+    required this.child,
+    LocalKey? key,
     String? name,
     Object? arguments,
     String? restorationId,
-    LocalKey? key,
   }) : super(
-          transitionsBuilder: _transitionsBuilder,
-          transitionDuration: const Duration(microseconds: 1), // hack for #205
+          pageBuilder: (context, animation, secondaryAnimation) => child,
+          transitionsBuilder:
+              (context, animation, secondaryAnimation, lchild) => lchild,
+          transitionDuration: const Duration(microseconds: 1),
           key: key,
           name: name,
           arguments: arguments,
           restorationId: restorationId,
-          child: child,
         );
-
-  static Widget _transitionsBuilder(
-          BuildContext context,
-          Animation<double> animation,
-          Animation<double> secondaryAnimation,
-          Widget child) =>
-      child;
+  final Widget child;
 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
The barrierdissmissable property of customtransitionpage was not working. this bug is fixed also introduced pageBuilder instead of child in customTransitionPage which gives more control for animation 


### :arrow_heading_down: What is the current behavior?
the dialog is not dissmissing after touching outside screen after making the barrierdissmissable property of customtransitionpage to true

Also the child property of CustomTransitionPage dosent give more control over animation

### :new: What is the new behavior (if this is a feature change)?
making the barrierDismmissable property to true makes the dialog dissmissable after pressing outside

more control over animation 



### :boom: Does this PR introduce a breaking change?
no


### :bug: Recommendations for testing
yes


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [yes ] I made sure all projects build.
- [ no] I updated CHANGELOG.md to add a description of the change.
- [no ] I updated the relevant documentation.
- [ yes] I updated the relevant code example.
- [ no] I rebased onto current `master`.
